### PR TITLE
[codex] v0.1.3 release branch

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -37,7 +37,7 @@ When making changes, prefer the smallest validation that proves correctness:
   - CLI command group `jenkins`
   - Entrypoints: `jenkins-cmd` and `serverlist`
 - Treat `tools/rigor-cli/` as a vendored subtree; do not edit it directly unless the task is to refresh that subtree.
-- **Critical:** `bin/pyjenkinsapi-lint`, `bin/pyjenkinsapi-review`, `.github/copilot-instructions.md`, and `tools/rigor-cli/` form a tightly-coupled pipeline unit. Do not delete or rename these files or their hard-coded paths without updating all related scripts and CI configuration simultaneously. Azure pipeline depends on all three (see azure-pipelines.yml lines 44–65).
+- **Critical:** `bin/ai-bootstrap`, `bin/ai-lint`, `bin/ai-review`, `bin/ai-upload`, the legacy `bin/pyjenkinsapi-review` alias, `.github/copilot-instructions.md`, and `tools/rigor-cli/` form a tightly-coupled pipeline unit. Do not delete or rename these files or their call paths without updating all related scripts and CI configuration simultaneously.
 
 ## Preferred Refactor Pattern
 1. Confirm existing behavior from source.

--- a/.clinerules
+++ b/.clinerules
@@ -35,7 +35,9 @@ When making changes, prefer the smallest validation that proves correctness:
 - Keep existing public interfaces stable:
   - `jenkinsapi.core.Jenkins`
   - CLI command group `jenkins`
+  - Entrypoints: `jenkins-cmd` and `serverlist`
 - Treat `tools/rigor-cli/` as a vendored subtree; do not edit it directly unless the task is to refresh that subtree.
+- **Critical:** `bin/pyjenkinsapi-lint`, `bin/pyjenkinsapi-review`, `.github/copilot-instructions.md`, and `tools/rigor-cli/` form a tightly-coupled pipeline unit. Do not delete or rename these files or their hard-coded paths without updating all related scripts and CI configuration simultaneously. Azure pipeline depends on all three (see azure-pipelines.yml lines 44–65).
 
 ## Preferred Refactor Pattern
 1. Confirm existing behavior from source.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,20 +28,17 @@ The two public CLI entrypoints must remain stable—changing names, flags, or ou
 
 ### Critical Dependency: `bin/`, `tools/rigor-cli/`, and `.github/copilot-instructions.md`
 
-These three components form a tightly-coupled unit used by Azure CI and local development:
+These components form a tightly-coupled unit used by CI and local development:
 
-**`bin/pyjenkinsapi-lint`** — Runs `tools/rigor-cli/bin/rigor lint` with Python backend (ruff). Hard-coded path at line 36.
+**`bin/ai-bootstrap` / `bin/ai-lint` / `bin/ai-review` / `bin/ai-upload`** — repo-local helper entrypoints used by the validation and automation workflows.
 
-**`bin/pyjenkinsapi-review`** — Runs `tools/rigor-cli/bin/rigor review` with repo-specific guidance. Hard-coded path at lines 31, 115. Reads `.github/copilot-instructions.md` and passes it to the review tool. **Deleting the instructions file will break this script.**
+**`bin/pyjenkinsapi-review`** — legacy compatibility alias that forwards to `bin/ai-review` so older scripts and habits keep working.
 
-**Azure Pipeline** (`azure-pipelines.yml` lines 44–65) — Calls `bin/pyjenkinsapi-lint` and `bin/pyjenkinsapi-review` as CI stages. Requires `.github/copilot-instructions.md` to exist.
+**`tools/rigor-cli/`** — vendored subtree that provides the review/lint backend used by the helper wrappers.
 
-**Do not delete or rename:**
-- `tools/rigor-cli/` — vendored subtree; do not edit directly unless the task is explicitly a subtree refresh
-- `.github/copilot-instructions.md` — required by both `bin/pyjenkinsapi-review` and Azure CI
-- The hard-coded paths in `bin/pyjenkinsapi-lint` and `bin/pyjenkinsapi-review`
+**`.github/copilot-instructions.md`** — repo-specific review guidance consumed by `bin/ai-review` when Copilot is asked to review a change set.
 
-If you need to change or remove any of these, update all three files together and verify the Azure pipeline still works.
+If you need to change or remove any of these, update the wrapper scripts, CI configuration, and docs together and verify the pipeline still works.
 
 ## Repository Boundaries
 - Treat `tools/rigor-cli/` as read-only vendored tooling (see **Critical Dependency** above).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,23 +1,51 @@
 # Copilot Instructions for `pyjenkinsapi`
 
 ## Role
-- Review this repository as a compatibility-sensitive Jenkins client and CLI project.
-- Prefer repo-specific, actionable review comments over generic style notes.
-- Use the prompt for the current change set as the primary source of review context.
+- Treat this as a compatibility-sensitive Jenkins client and CLI project.
+- Prefer repo-specific, actionable guidance over generic style notes.
+- When making code changes, think of this as a code + tooling + CI system; changes can cascade across build/review/pipeline.
+- When reviewing, use the prompt for the current change set as the primary source of review context.
+
+## CLI Entrypoints (Stable)
+The two public CLI entrypoints must remain stable—changing names, flags, or output format is a breaking change:
+- `jenkins-cmd` — primary Jenkins view/job inspector (see `jenkinsapi.scripts.jenkins_cli:jenkins`)
+- `serverlist` — legacy server list helper (see `jenkinsapi.scripts.serverlist:main`)
+
+## Code Change Priorities
+- Preserve backward compatibility, especially `jenkinsapi.core.Jenkins` and existing import paths.
+- Treat config-driven Jenkins auth (via `jenkins.ini`) as the default pattern—never hardcode credentials, tokens, org/project names, or Jenkins URLs.
+- Use `jenkinsapi.config.core.config_section_map()` to parse config sections; example: `config = config_section_map('lcjenkins')` yields `{'url': '...', 'user': '...', 'password': '...'}`
+- Favor minimal, surgical edits over broad rewrites.
+- Do not log or print plaintext secrets.
+- Preserve legacy Python patterns (e.g., `from __future__ import print_function`) unless explicitly requested.
 
 ## Review Priorities
-- Preserve backward compatibility, especially `jenkinsapi.core.Jenkins` and existing import paths.
-- Keep CLI entrypoints, command names, and flag meanings stable unless the task explicitly changes them.
-- Favor minimal, surgical edits over broad rewrites.
-- Treat config-driven Jenkins auth as the default pattern.
-- Never hardcode credentials, tokens, org/project names, or Jenkins URLs.
+- Preserve backward compatibility and CLI stability as noted above.
 - Review behavior changes before style-only suggestions.
 - Call out missing tests or docs when behavior changes.
 
+## Build and Validation Pipeline
+
+### Critical Dependency: `bin/`, `tools/rigor-cli/`, and `.github/copilot-instructions.md`
+
+These three components form a tightly-coupled unit used by Azure CI and local development:
+
+**`bin/pyjenkinsapi-lint`** — Runs `tools/rigor-cli/bin/rigor lint` with Python backend (ruff). Hard-coded path at line 36.
+
+**`bin/pyjenkinsapi-review`** — Runs `tools/rigor-cli/bin/rigor review` with repo-specific guidance. Hard-coded path at lines 31, 115. Reads `.github/copilot-instructions.md` and passes it to the review tool. **Deleting the instructions file will break this script.**
+
+**Azure Pipeline** (`azure-pipelines.yml` lines 44–65) — Calls `bin/pyjenkinsapi-lint` and `bin/pyjenkinsapi-review` as CI stages. Requires `.github/copilot-instructions.md` to exist.
+
+**Do not delete or rename:**
+- `tools/rigor-cli/` — vendored subtree; do not edit directly unless the task is explicitly a subtree refresh
+- `.github/copilot-instructions.md` — required by both `bin/pyjenkinsapi-review` and Azure CI
+- The hard-coded paths in `bin/pyjenkinsapi-lint` and `bin/pyjenkinsapi-review`
+
+If you need to change or remove any of these, update all three files together and verify the Azure pipeline still works.
+
 ## Repository Boundaries
-- Treat `tools/rigor-cli/` as vendored tooling.
-- Do not suggest editing `tools/rigor-cli/` unless the task is explicitly a subtree refresh.
-- Treat files under `bin/` as repo-local maintenance and pipeline helpers unless the task says otherwise.
+- Treat `tools/rigor-cli/` as read-only vendored tooling (see **Critical Dependency** above).
+- Treat files under `bin/` as repo-local maintenance and pipeline helpers integral to CI (see **Critical Dependency** above).
 - Keep Azure helper scripts aligned with their documented prompt/fail-fast behavior.
 
 ## What to Flag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bats scripts/tests/pyjenkinsapi-review.bats
+          bats scripts/tests/ai-review.bats
 
   review:
     needs: lint
@@ -125,7 +125,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          review_file="$RUNNER_TEMP/pyjenkinsapi-review.diff"
+          review_file="$RUNNER_TEMP/ai-review.diff"
           git diff --binary origin/main...HEAD >"$review_file"
           printf 'PYJENKINSAPI_REVIEW_DIFF=%s\n' "$review_file" >> "$GITHUB_ENV"
 
@@ -134,6 +134,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          bin/pyjenkinsapi-review \
+          bin/ai-review \
             --prompt "Review this pull request diff for correctness, compatibility, and risky changes." \
             --prompt-file "$PYJENKINSAPI_REVIEW_DIFF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,11 @@ jobs:
           git diff --no-ext-diff --no-color origin/main...HEAD >"$review_file"
           if [[ "$(wc -c <"$review_file")" -gt 524288 ]]; then
             printf 'WARN: review context exceeds 512 KiB; truncating to keep prompt size manageable\n' >&2
-            head -c 524288 "$review_file" >"${review_file}.trimmed"
+            echo "::warning file=.github/workflows/ci.yml::Review context exceeds 512 KiB; the diff was truncated and the automated review will be incomplete — findings in later files may be missed."
+            truncation_marker=$'\n[TRUNCATED: diff exceeded 512 KiB -- review context is incomplete; later files were omitted]\n'
+            marker_len=$(printf '%s' "$truncation_marker" | wc -c)
+            head -c $((524288 - marker_len)) "$review_file" >"${review_file}.trimmed"
+            printf '%s' "$truncation_marker" >>"${review_file}.trimmed"
             mv "${review_file}.trimmed" "$review_file"
           fi
           printf 'PYJENKINSAPI_REVIEW_DIFF=%s\n' "$review_file" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t files < <(
-            find bin -maxdepth 1 -type f -name 'pyjenkinsapi-*' | sort
+            find bin -maxdepth 1 -type f \( -name 'ai-*' -o -name 'pyjenkinsapi-review' \) | sort
           )
           shellcheck -S error "${files[@]}"
 
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          find bin -maxdepth 1 -type f -name 'pyjenkinsapi-*' -print0 |
+          find bin -maxdepth 1 -type f \( -name 'ai-*' -o -name 'pyjenkinsapi-review' \) -print0 |
           while IFS= read -r -d '' file; do
             bash -n "$file"
           done
@@ -126,7 +126,12 @@ jobs:
         run: |
           set -euo pipefail
           review_file="$RUNNER_TEMP/ai-review.diff"
-          git diff --binary origin/main...HEAD >"$review_file"
+          git diff --no-ext-diff --no-color origin/main...HEAD >"$review_file"
+          if [[ "$(wc -c <"$review_file")" -gt 524288 ]]; then
+            printf 'WARN: review context exceeds 512 KiB; truncating to keep prompt size manageable\n' >&2
+            head -c 524288 "$review_file" >"${review_file}.trimmed"
+            mv "${review_file}.trimmed" "$review_file"
+          fi
           printf 'PYJENKINSAPI_REVIEW_DIFF=%s\n' "$review_file" >> "$GITHUB_ENV"
 
       - name: Run review wrapper

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ serverlist
 ### 4. Verify local tooling
 
 ```bash
-bash -n bin/pyjenkinsapi-review
-shellcheck -S warning bin/pyjenkinsapi-review
-bats scripts/tests/pyjenkinsapi-review.bats
+bash -n bin/ai-review
+shellcheck -S warning bin/ai-review
+bats scripts/tests/ai-review.bats
 ```
 
 ---
@@ -149,5 +149,5 @@ setup.py               # package metadata and console scripts
 
 - GitHub Actions CI lives in `.github/workflows/ci.yml` and runs a lint job plus an optional PR review job on pull requests to `main`.
 - `tools/rigor-cli/` is vendored and should be treated as read-only unless a task explicitly refreshes the subtree.
-- `bin/pyjenkinsapi-review` is intentionally PR-style and local-first; it does not mutate the review prompt file on disk.
+- `bin/ai-review` is intentionally PR-style and local-first; it does not mutate the review prompt file on disk.
 - If you change the CLI surface, update the memory bank and the relevant plan docs together.

--- a/README.md
+++ b/README.md
@@ -152,4 +152,5 @@ setup.py               # package metadata and console scripts
 - `bin/ai-review` is intentionally PR-style and local-first; it does not mutate the review prompt file on disk.
 - `bin/ai-review` also accepts piped stdin as review context, so `git diff main...HEAD | bin/ai-review` works naturally.
 - `bin/ai-review --help` now mentions stdin usage directly.
+- `bin/ai-review --fail-on-findings` or `--exit-code` can be used in CI when review findings should fail the job.
 - If you change the CLI surface, update the memory bank and the relevant plan docs together.

--- a/README.md
+++ b/README.md
@@ -150,4 +150,5 @@ setup.py               # package metadata and console scripts
 - GitHub Actions CI lives in `.github/workflows/ci.yml` and runs a lint job plus an optional PR review job on pull requests to `main`.
 - `tools/rigor-cli/` is vendored and should be treated as read-only unless a task explicitly refreshes the subtree.
 - `bin/ai-review` is intentionally PR-style and local-first; it does not mutate the review prompt file on disk.
+- `bin/ai-review` also accepts piped stdin as review context, so `git diff main...HEAD | bin/ai-review` works naturally.
 - If you change the CLI surface, update the memory bank and the relevant plan docs together.

--- a/README.md
+++ b/README.md
@@ -151,4 +151,5 @@ setup.py               # package metadata and console scripts
 - `tools/rigor-cli/` is vendored and should be treated as read-only unless a task explicitly refreshes the subtree.
 - `bin/ai-review` is intentionally PR-style and local-first; it does not mutate the review prompt file on disk.
 - `bin/ai-review` also accepts piped stdin as review context, so `git diff main...HEAD | bin/ai-review` works naturally.
+- `bin/ai-review --help` now mentions stdin usage directly.
 - If you change the CLI surface, update the memory bank and the relevant plan docs together.

--- a/README.md
+++ b/README.md
@@ -153,4 +153,5 @@ setup.py               # package metadata and console scripts
 - `bin/ai-review` also accepts piped stdin as review context, so `git diff main...HEAD | bin/ai-review` works naturally.
 - `bin/ai-review --help` now mentions stdin usage directly.
 - `bin/ai-review --fail-on-findings` or `--exit-code` can be used in CI when review findings should fail the job.
+- `bin/pyjenkinsapi-review` remains as a compatibility alias for older scripts and simply forwards to `bin/ai-review`.
 - If you change the CLI surface, update the memory bank and the relevant plan docs together.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ stages:
           - bash: |
               set -euo pipefail
               cd "$(Build.SourcesDirectory)"
-              bin/pyjenkinsapi-bootstrap --backend-cmd "$PYJENKINSAPI_LINT_BACKEND_CMD" --install
+              bin/ai-bootstrap --backend-cmd "$PYJENKINSAPI_LINT_BACKEND_CMD" --install
               user_bin_dir="$(python3 -m site --user-base)/bin"
               echo "##vso[task.prependpath]$user_bin_dir"
               command -v "$PYJENKINSAPI_LINT_BACKEND_CMD" >/dev/null 2>&1
@@ -50,13 +50,13 @@ stages:
           - bash: |
               set -euo pipefail
               cd "$(Build.SourcesDirectory)"
-              bin/pyjenkinsapi-lint
+              bin/ai-lint
             displayName: Lint
 
           - bash: |
               set -euo pipefail
               cd "$(Build.SourcesDirectory)"
-              bin/pyjenkinsapi-review
+              bin/ai-review
             displayName: Review
             env:
               GH_TOKEN: $(COPILOT_GITHUB_TOKEN)

--- a/bin/ai-bootstrap
+++ b/bin/ai-bootstrap
@@ -7,7 +7,7 @@ _repo_root() {
 
 _usage() {
   cat <<'EOF'
-Usage: pyjenkinsapi-bootstrap [--backend-cmd CMD] [--install]
+Usage: ai-bootstrap [--backend-cmd CMD] [--install]
 
 Prepare the local lint backend for pyjenkinsapi.
 

--- a/bin/ai-lint
+++ b/bin/ai-lint
@@ -7,7 +7,7 @@ _repo_root() {
 
 _usage() {
   cat <<'EOF'
-Usage: pyjenkinsapi-lint [rigor lint args...]
+Usage: ai-lint [rigor lint args...]
 
 Run rigor lint with the repo-local Python backend mapping.
 EOF

--- a/bin/ai-review
+++ b/bin/ai-review
@@ -9,7 +9,7 @@ _usage() {
   cat <<'EOF'
 Usage: ai-review [--prompt TEXT] [--prompt-file FILE] [--model MODEL] [rigor review args...]
 
-Run rigor review with a repo-local default prompt and Copilot instructions.
+Run rigor review with a repo-local default prompt, stdin support, and Copilot instructions.
 EOF
 }
 
@@ -44,6 +44,8 @@ prompt_file=""
 model="${PYJENKINSAPI_REVIEW_MODEL:-}"
 stream_mode="${PYJENKINSAPI_REVIEW_STREAM:-on}"
 inline_prompt_file="${PYJENKINSAPI_REVIEW_INLINE_PROMPT_FILE:-0}"
+stdin_contents=""
+stdin_has_data=0
 
 repo_root="$(_repo_root || true)"
 [[ -n "$repo_root" ]] || _warn "Not inside a git repository; using current directory"
@@ -92,13 +94,35 @@ done
 
 prompt="$(_redact_forbidden_fragments "$prompt")"
 
+if [[ ! -t 0 ]]; then
+  stdin_contents="$(cat)"
+  if [[ -n "$stdin_contents" ]]; then
+    stdin_has_data=1
+    stdin_contents="$(_redact_forbidden_fragments "$stdin_contents")"
+  fi
+fi
+
 if [[ -n "$prompt_file" ]]; then
   [[ -f "$prompt_file" ]] || { printf 'ERROR: prompt file not found: %s\n' "$prompt_file" >&2; exit 1; }
   prompt_file_contents="$(_redact_forbidden_fragments "$(cat "$prompt_file")")"
-  sanitized_prompt_file="$(mktemp "${TMPDIR:-/tmp}/ai-review.XXXXXX")"
-  printf '%s' "$prompt_file_contents" >"$sanitized_prompt_file"
 else
   prompt_file_contents=""
+fi
+
+if [[ -n "$prompt_file_contents" || "$stdin_has_data" -eq 1 ]]; then
+  sanitized_prompt_file="$(mktemp "${TMPDIR:-/tmp}/ai-review.XXXXXX")"
+  if [[ -n "$prompt_file_contents" && "$stdin_has_data" -eq 1 ]]; then
+    {
+      printf -- '--- %s ---\n' "--prompt-file (${prompt_file})"
+      printf '%s\n\n' "$prompt_file_contents"
+      printf -- '--- stdin ---\n'
+      printf '%s' "$stdin_contents"
+    } >"$sanitized_prompt_file"
+  elif [[ -n "$prompt_file_contents" ]]; then
+    printf '%s' "$prompt_file_contents" >"$sanitized_prompt_file"
+  else
+    printf '%s' "$stdin_contents" >"$sanitized_prompt_file"
+  fi
 fi
 
 review_args=()
@@ -128,19 +152,51 @@ final_prompt="$review_style_prompt
 Review instruction:
 $prompt"
 
-if [[ -n "$prompt_file_contents" ]]; then
+if [[ -n "$prompt_file_contents" || "$stdin_has_data" -eq 1 ]]; then
   if [[ "$inline_prompt_file" -eq 1 ]]; then
-    final_prompt="$final_prompt
+    if [[ -n "$prompt_file_contents" && "$stdin_has_data" -eq 1 ]]; then
+      final_prompt="$final_prompt
+
+Review context from --prompt-file (${prompt_file}) and stdin:
+--- prompt-file (${prompt_file}) ---
+$prompt_file_contents
+
+--- stdin ---
+$stdin_contents"
+    elif [[ -n "$prompt_file_contents" ]]; then
+      final_prompt="$final_prompt
 
 Review context from --prompt-file (${prompt_file}):
 $prompt_file_contents"
+    else
+      final_prompt="$final_prompt
+
+Review context from stdin:
+$stdin_contents"
+    fi
   else
-    final_prompt="$final_prompt
+    if [[ -n "$prompt_file_contents" && "$stdin_has_data" -eq 1 ]]; then
+      final_prompt="$final_prompt
+
+Review context file:
+$sanitized_prompt_file
+
+Inspect that file for the diff or context to review. It contains both the prompt-file and stdin content. Summarize findings in PR style."
+    elif [[ -n "$prompt_file_contents" ]]; then
+      final_prompt="$final_prompt
 
 Review context file:
 $sanitized_prompt_file
 
 Inspect that file for the diff or context to review. Summarize findings in PR style."
+    else
+      final_prompt="$final_prompt
+
+Review context file:
+$sanitized_prompt_file
+
+Inspect that file for the diff or context to review. Summarize findings in PR style."
+    fi
   fi
 fi
 

--- a/bin/ai-review
+++ b/bin/ai-review
@@ -48,7 +48,6 @@ prompt="${PYJENKINSAPI_REVIEW_PROMPT:-$default_prompt}"
 prompt_file=""
 model="${PYJENKINSAPI_REVIEW_MODEL:-}"
 stream_mode="${PYJENKINSAPI_REVIEW_STREAM:-on}"
-inline_prompt_file="${PYJENKINSAPI_REVIEW_INLINE_PROMPT_FILE:-0}"
 stdin_contents=""
 stdin_has_data=0
 
@@ -57,13 +56,6 @@ repo_root="$(_repo_root || true)"
 repo_root="${repo_root:-$(pwd)}"
 cd "$repo_root"
 rigor_bin="${PYJENKINSAPI_RIGOR_BIN:-$repo_root/tools/rigor-cli/bin/rigor}"
-sanitized_prompt_file=""
-cleanup_sanitized_prompt_file() {
-  if [[ -n "$sanitized_prompt_file" && -f "$sanitized_prompt_file" ]]; then
-    rm -f "$sanitized_prompt_file"
-  fi
-}
-trap cleanup_sanitized_prompt_file EXIT INT TERM HUP
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -114,22 +106,6 @@ else
   prompt_file_contents=""
 fi
 
-if [[ -n "$prompt_file_contents" || "$stdin_has_data" -eq 1 ]]; then
-  sanitized_prompt_file="$(mktemp "${TMPDIR:-/tmp}/ai-review.XXXXXX")"
-  if [[ -n "$prompt_file_contents" && "$stdin_has_data" -eq 1 ]]; then
-    {
-      printf -- '--- %s ---\n' "--prompt-file (${prompt_file})"
-      printf '%s\n\n' "$prompt_file_contents"
-      printf -- '--- stdin ---\n'
-      printf '%s' "$stdin_contents"
-    } >"$sanitized_prompt_file"
-  elif [[ -n "$prompt_file_contents" ]]; then
-    printf '%s' "$prompt_file_contents" >"$sanitized_prompt_file"
-  else
-    printf '%s' "$stdin_contents" >"$sanitized_prompt_file"
-  fi
-fi
-
 review_args=()
 if [[ -n "$model" ]]; then
   review_args+=(--model "$model")
@@ -157,57 +133,18 @@ final_prompt="$review_style_prompt
 Review instruction:
 $prompt"
 
-if [[ -n "$prompt_file_contents" || "$stdin_has_data" -eq 1 ]]; then
-  if [[ "$inline_prompt_file" -eq 1 ]]; then
-    if [[ -n "$prompt_file_contents" && "$stdin_has_data" -eq 1 ]]; then
-      final_prompt="$final_prompt
-
-Review context from --prompt-file (${prompt_file}) and stdin:
---- prompt-file (${prompt_file}) ---
-$prompt_file_contents
-
---- stdin ---
-$stdin_contents"
-    elif [[ -n "$prompt_file_contents" ]]; then
-      final_prompt="$final_prompt
+if [[ -n "$prompt_file_contents" ]]; then
+  final_prompt="$final_prompt
 
 Review context from --prompt-file (${prompt_file}):
 $prompt_file_contents"
-    else
-      final_prompt="$final_prompt
+fi
+
+if [[ "$stdin_has_data" -eq 1 ]]; then
+  final_prompt="$final_prompt
 
 Review context from stdin:
 $stdin_contents"
-    fi
-  else
-    if [[ -n "$prompt_file_contents" && "$stdin_has_data" -eq 1 ]]; then
-      final_prompt="$final_prompt
-
-Review context file:
-$sanitized_prompt_file
-
-Inspect that file for the diff or context to review. It contains both the prompt-file and stdin content. Summarize findings in PR style."
-    elif [[ -n "$prompt_file_contents" ]]; then
-      final_prompt="$final_prompt
-
-Review context file:
-$sanitized_prompt_file
-
-Inspect that file for the diff or context to review. Summarize findings in PR style."
-    else
-      final_prompt="$final_prompt
-
-Review context file:
-$sanitized_prompt_file
-
-Inspect that file for the diff or context to review. Summarize findings in PR style."
-    fi
-  fi
 fi
 
-rigor_prompt_args=()
-if [[ -n "$sanitized_prompt_file" ]]; then
-  rigor_prompt_args+=(--prompt-file "$sanitized_prompt_file")
-fi
-
-exec "$rigor_bin" review --prompt "$final_prompt" "${review_args[@]}" "${rigor_prompt_args[@]}" "$@"
+exec "$rigor_bin" review --prompt "$final_prompt" "${review_args[@]}" "$@"

--- a/bin/ai-review
+++ b/bin/ai-review
@@ -46,12 +46,12 @@ _redact_forbidden_fragments() {
   printf '%s' "$text"
 }
 
-default_prompt='Review this pyjenkinsapi change for correctness, backward compatibility, config-driven credential handling, secret handling, and missing tests or docs. Prioritize behavior regressions and compatibility risks over style-only comments.'
-prompt="${PYJENKINSAPI_REVIEW_PROMPT:-$default_prompt}"
+default_prompt='Review this pyjenkinsapi change for correctness, backward compatibility, config-driven credential handling, secret handling, and missing tests or docs, and generate applicable path. Prioritize behavior regressions and compatibility risks over style-only comments.'
+prompt="${AI_REVIEW_PROMPT:-$default_prompt}"
 prompt_file=""
-model="${PYJENKINSAPI_REVIEW_MODEL:-}"
-stream_mode="${PYJENKINSAPI_REVIEW_STREAM:-on}"
-fail_on_findings="${PYJENKINSAPI_REVIEW_FAIL_ON_FINDINGS:-0}"
+model="${AI_REVIEW_MODEL:-}"
+stream_mode="${AI_REVIEW_STREAM:-on}"
+fail_on_findings="${AI_REVIEW_FAIL_ON_FINDINGS:-0}"
 stdin_contents=""
 stdin_has_data=0
 
@@ -59,7 +59,7 @@ repo_root="$(_repo_root || true)"
 [[ -n "$repo_root" ]] || _warn "Not inside a git repository; using current directory"
 repo_root="${repo_root:-$(pwd)}"
 cd "$repo_root"
-rigor_bin="${PYJENKINSAPI_RIGOR_BIN:-$repo_root/tools/rigor-cli/bin/rigor}"
+rigor_bin="${AI_RIGOR_BIN:-$repo_root/tools/rigor-cli/bin/rigor}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/bin/ai-review
+++ b/bin/ai-review
@@ -10,6 +10,11 @@ _usage() {
 Usage: ai-review [--prompt TEXT] [--prompt-file FILE] [--model MODEL] [rigor review args...]
 
 Run rigor review with a repo-local default prompt, stdin support, and Copilot instructions.
+
+Piped stdin is accepted as review context. For example:
+  git diff main...HEAD | bin/ai-review
+
+Use --prompt for the review instruction and --prompt-file for file-based context.
 EOF
 }
 

--- a/bin/ai-review
+++ b/bin/ai-review
@@ -7,7 +7,7 @@ _repo_root() {
 
 _usage() {
   cat <<'EOF'
-Usage: ai-review [--prompt TEXT] [--prompt-file FILE] [--model MODEL] [rigor review args...]
+Usage: ai-review [--prompt TEXT] [--prompt-file FILE] [--model MODEL] [--fail-on-findings|--exit-code] [rigor review args...]
 
 Run rigor review with a repo-local default prompt, stdin support, and Copilot instructions.
 
@@ -15,6 +15,9 @@ Piped stdin is accepted as review context. For example:
   git diff main...HEAD | bin/ai-review
 
 Use --prompt for the review instruction and --prompt-file for file-based context.
+
+Use --fail-on-findings or --exit-code when CI should return non-zero for review findings.
+In that mode, the review output must end with AI_REVIEW_RESULT: findings or AI_REVIEW_RESULT: no-findings.
 EOF
 }
 
@@ -48,6 +51,7 @@ prompt="${PYJENKINSAPI_REVIEW_PROMPT:-$default_prompt}"
 prompt_file=""
 model="${PYJENKINSAPI_REVIEW_MODEL:-}"
 stream_mode="${PYJENKINSAPI_REVIEW_STREAM:-on}"
+fail_on_findings="${PYJENKINSAPI_REVIEW_FAIL_ON_FINDINGS:-0}"
 stdin_contents=""
 stdin_has_data=0
 
@@ -73,6 +77,9 @@ while [[ $# -gt 0 ]]; do
       shift
       [[ $# -gt 0 ]] || { printf 'ERROR: --model requires a value\n' >&2; exit 1; }
       model="$1"
+      ;;
+    --fail-on-findings|--exit-code)
+      fail_on_findings=1
       ;;
     -h|--help)
       _usage
@@ -133,6 +140,12 @@ final_prompt="$review_style_prompt
 Review instruction:
 $prompt"
 
+if [[ "$fail_on_findings" -eq 1 ]]; then
+  final_prompt="$final_prompt
+
+When you finish, end with exactly one final line of either AI_REVIEW_RESULT: findings if there are one or more findings, or AI_REVIEW_RESULT: no-findings if there are no findings."
+fi
+
 if [[ -n "$prompt_file_contents" ]]; then
   final_prompt="$final_prompt
 
@@ -145,6 +158,33 @@ if [[ "$stdin_has_data" -eq 1 ]]; then
 
 Review context from stdin:
 $stdin_contents"
+fi
+
+if [[ "$fail_on_findings" -eq 1 ]]; then
+  review_output_file="$(mktemp "${TMPDIR:-/tmp}/ai-review-output.XXXXXX")"
+  cleanup_review_output_file() {
+    [[ -n "${review_output_file:-}" && -f "$review_output_file" ]] && rm -f "$review_output_file"
+  }
+  trap cleanup_review_output_file EXIT INT TERM HUP
+
+  set +e
+  "$rigor_bin" review --prompt "$final_prompt" "${review_args[@]}" "$@" >"$review_output_file" 2>&1
+  review_rc=$?
+  set -e
+
+  cat "$review_output_file"
+  if [[ "$review_rc" -ne 0 ]]; then
+    exit "$review_rc"
+  fi
+  if grep -q '^AI_REVIEW_RESULT: findings$' "$review_output_file"; then
+    exit 1
+  fi
+  if grep -q '^AI_REVIEW_RESULT: no-findings$' "$review_output_file"; then
+    exit 0
+  fi
+
+  _warn "Review output did not include AI_REVIEW_RESULT marker; failing closed"
+  exit 1
 fi
 
 exec "$rigor_bin" review --prompt "$final_prompt" "${review_args[@]}" "$@"

--- a/bin/ai-review
+++ b/bin/ai-review
@@ -7,7 +7,7 @@ _repo_root() {
 
 _usage() {
   cat <<'EOF'
-Usage: pyjenkinsapi-review [--prompt TEXT] [--prompt-file FILE] [--model MODEL] [rigor review args...]
+Usage: ai-review [--prompt TEXT] [--prompt-file FILE] [--model MODEL] [rigor review args...]
 
 Run rigor review with a repo-local default prompt and Copilot instructions.
 EOF
@@ -95,7 +95,7 @@ prompt="$(_redact_forbidden_fragments "$prompt")"
 if [[ -n "$prompt_file" ]]; then
   [[ -f "$prompt_file" ]] || { printf 'ERROR: prompt file not found: %s\n' "$prompt_file" >&2; exit 1; }
   prompt_file_contents="$(_redact_forbidden_fragments "$(cat "$prompt_file")")"
-  sanitized_prompt_file="$(mktemp "${TMPDIR:-/tmp}/pyjenkinsapi-review.XXXXXX")"
+  sanitized_prompt_file="$(mktemp "${TMPDIR:-/tmp}/ai-review.XXXXXX")"
   printf '%s' "$prompt_file_contents" >"$sanitized_prompt_file"
 else
   prompt_file_contents=""

--- a/bin/ai-upload
+++ b/bin/ai-upload
@@ -6,7 +6,7 @@ repo_root="$(git -C "$script_dir/.." rev-parse --show-toplevel 2>/dev/null || tr
 
 _usage() {
   cat <<'EOF'
-Usage: pyjenkinsapi-azure-upload [options]
+Usage: ai-upload [options]
 
 Upload the local pyjenkinsapi repository to Azure DevOps and keep a git remote
 in sync.

--- a/bin/pyjenkinsapi-review
+++ b/bin/pyjenkinsapi-review
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec "$script_dir/ai-review" "$@"

--- a/docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md
+++ b/docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md
@@ -1,0 +1,66 @@
+# Bug: `ai-review` forwards an unsupported `--prompt-file` flag to the backend
+
+**Date:** 2026-05-04  
+**Branch:** `pyjenkinsapi-v0.1.1`
+
+---
+
+## Problem
+
+`bin/ai-review` accepts stdin and `--prompt-file` content, sanitizes them into a temp file, and then forwards that temp file to the vendored `rigor` backend using `--prompt-file`.
+
+That is not supported by the backend path. When the wrapper is used with piped input, the backend fails with:
+
+```text
+error: unknown option '--prompt-file'
+```
+
+The temp file should stay internal to `ai-review`; the backend only understands `--prompt`.
+
+---
+
+## Actual Behavior
+
+- `ai-review` reads stdin and/or `--prompt-file`.
+- `ai-review` writes combined context into a temp file.
+- `ai-review` forwards `--prompt-file <tempfile>` to `rigor review`.
+- The backend rejects the unsupported option and exits non-zero.
+
+---
+
+## Expected Behavior
+
+- `ai-review` should keep the combined context temp file internal.
+- `ai-review` should pass only `--prompt` and supported `rigor review` arguments to the backend.
+- Stdin and prompt-file content should still be merged for the wrapper’s internal prompt assembly.
+
+---
+
+## Recommended Fix
+
+- Remove the forwarded `--prompt-file` argument from the backend invocation.
+- Keep the combined temp file only as an internal wrapper artifact.
+- Ensure the current redaction and PR-style output contract still apply.
+
+---
+
+## Validation Notes
+
+Repro:
+
+```bash
+git diff ..main | bin/ai-review
+```
+
+Observed failure:
+
+```text
+error: unknown option '--prompt-file'
+```
+
+---
+
+## Follow-Up
+
+- Patch `bin/ai-review` to stop passing `--prompt-file` to the backend.
+- Re-run the stdin smoke test and BATS coverage after the fix.

--- a/docs/bugs/2026-05-04-ai-review-stdin-help-missing.md
+++ b/docs/bugs/2026-05-04-ai-review-stdin-help-missing.md
@@ -1,0 +1,61 @@
+# Bug: `ai-review` accepts stdin but does not document it in `--help`
+
+**Date:** 2026-05-04  
+**Branch:** `pyjenkinsapi-v0.1.1`
+
+---
+
+## Problem
+
+`bin/ai-review` accepts review context from piped stdin, but the usage/help text does not mention that behavior. Users can discover the feature only by reading the script or by trial and error.
+
+That makes the interface misleading because the wrapper now supports:
+
+```bash
+git diff main...HEAD | bin/ai-review
+```
+
+but the help text still only lists `--prompt`, `--prompt-file`, and `--model`.
+
+---
+
+## Actual Behavior
+
+- `ai-review` reads stdin when input is piped in.
+- `ai-review --help` does not mention stdin support.
+- The README mentions stdin support, but the command-line help is the primary discoverability surface for the wrapper.
+
+---
+
+## Expected Behavior
+
+- `ai-review --help` should explain that piped stdin is accepted as review context.
+- The usage text should show stdin as an input source alongside `--prompt` and `--prompt-file`.
+- The help text should briefly show an example invocation.
+
+---
+
+## Recommended Fix
+
+- Update the `Usage:` line to mention stdin support.
+- Add a short help note that stdin is accepted when piped in.
+- Add an example like `git diff main...HEAD | bin/ai-review`.
+
+---
+
+## Validation Notes
+
+To confirm the gap:
+
+```bash
+bin/ai-review --help
+```
+
+The output currently omits stdin usage guidance.
+
+---
+
+## Follow-Up
+
+- Update `bin/ai-review` help text.
+- Adjust README wording if needed so the CLI help and docs stay aligned.

--- a/docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md
+++ b/docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md
@@ -1,0 +1,39 @@
+# Bug: `ai-review` wrapper must keep stdin support and avoid forwarding unsupported backend flags
+
+**Status:** Resolved in `bf47e67`
+**Branch:** `pyjenkinsapi-v0.1.1`
+**Files:** `bin/ai-review`, `scripts/tests/ai-review.bats`
+
+---
+
+## Problem
+
+Copilot review feedback flagged two regressions in the review wrapper:
+
+- the wrapper still forwarded `--prompt-file` to the vendored backend, even though the backend only accepts `--prompt`
+- the wrapper appeared to drop stdin-based review context, which would break `git diff ... | bin/ai-review` usage
+
+The intended behavior is that `ai-review` may accept stdin and prompt-file input locally, but any temp handling must remain internal to the wrapper and only supported backend flags should reach `rigor review`.
+
+## Expected Behavior
+
+- `bin/ai-review` should keep stdin review context working.
+- `bin/ai-review` should keep `--prompt-file` as an input source only, not as a forwarded backend flag.
+- The vendored backend should receive only supported `rigor review` arguments.
+
+## Root Cause
+
+The wrapper implementation initially mixed local temp-file handling with backend argument forwarding. That created a contract mismatch with the vendored `rigor review` CLI and risked breaking piped stdin workflows.
+
+## Resolution
+
+`bf47e67` fixes the wrapper so stdin and prompt-file content stay inline in the review prompt and no unsupported `--prompt-file` flag is forwarded to the backend. The local BATS suite now covers both stdin-only and stdin-plus-prompt-file cases.
+
+## Evidence
+
+Direct smoke validation after the fix showed:
+
+- `bin/ai-review` accepted piped stdin input
+- the backend saw only `--prompt`
+- no `unknown option '--prompt-file'` failure occurred
+

--- a/docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md
+++ b/docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md
@@ -1,0 +1,30 @@
+# Bug: legacy `pyjenkinsapi-review` entrypoint no longer has a compatibility alias
+
+**Status:** Open
+**Branch:** `pyjenkinsapi-v0.1.1`
+**Files:** `bin/pyjenkinsapi-review` (missing), `bin/ai-review`, `README.md`
+
+---
+
+## Problem
+
+The repo-local review wrapper was renamed to `bin/ai-review`, but there is no backward-compatible `bin/pyjenkinsapi-review` alias for older scripts, local habits, or CI jobs that still invoke the original name.
+
+That leaves the rename slightly more disruptive than intended, even though the new wrapper behavior itself is now compatible with stdin and CI failure modes.
+
+## Expected Behavior
+
+- `bin/ai-review` should remain the primary entrypoint.
+- `bin/pyjenkinsapi-review` should remain available as a thin compatibility shim.
+- The alias should preserve stdin review context and opt-in CI failure mode by delegating to `bin/ai-review` unchanged.
+
+## Why This Matters
+
+The review comments specifically called out a missing compatibility path. Without an alias, the rename forces every caller to switch at once, which is avoidable friction for a repo-local helper.
+
+## Resolution Plan
+
+- Add `bin/pyjenkinsapi-review` as a thin wrapper around `bin/ai-review`.
+- Add a smoke test that exercises the compatibility alias with stdin and CI failure mode behavior.
+- Record the compatibility shim in README/memory-bank notes.
+

--- a/docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md
+++ b/docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md
@@ -1,6 +1,6 @@
 # Bug: legacy `pyjenkinsapi-review` entrypoint no longer has a compatibility alias
 
-**Status:** Open
+**Status:** Resolved
 **Branch:** `pyjenkinsapi-v0.1.1`
 **Files:** `bin/pyjenkinsapi-review` (missing), `bin/ai-review`, `README.md`
 
@@ -22,9 +22,6 @@ That leaves the rename slightly more disruptive than intended, even though the n
 
 The review comments specifically called out a missing compatibility path. Without an alias, the rename forces every caller to switch at once, which is avoidable friction for a repo-local helper.
 
-## Resolution Plan
+## Resolution
 
-- Add `bin/pyjenkinsapi-review` as a thin wrapper around `bin/ai-review`.
-- Add a smoke test that exercises the compatibility alias with stdin and CI failure mode behavior.
-- Record the compatibility shim in README/memory-bank notes.
-
+`bin/pyjenkinsapi-review` now exists as a thin wrapper around `bin/ai-review`, and the local test suite exercises the compatibility alias with stdin and CI failure mode behavior.

--- a/docs/plans/2026-05-03-azure-ci-helper-tests.md
+++ b/docs/plans/2026-05-03-azure-ci-helper-tests.md
@@ -24,21 +24,21 @@ The tests should stay lightweight and avoid real Azure DevOps or Copilot side ef
 ## What to Test
 
 ### Repo-local wrappers
-- `bin/pyjenkinsapi-bootstrap`
+- `bin/ai-bootstrap`
   - help/usage output
   - missing backend handling
   - `--install` path with a stubbed installer
-- `bin/pyjenkinsapi-lint`
+- `bin/ai-lint`
   - default backend mapping
   - environment-variable overrides
   - argument pass-through to `rigor lint`
-- `bin/pyjenkinsapi-review`
+- `bin/ai-review`
   - default prompt selection
   - `--prompt`
   - `--prompt-file`
   - `--model`
   - warning path for missing `.github/copilot-instructions.md`
-- `bin/pyjenkinsapi-azure-upload`
+- `bin/ai-upload`
   - option parsing and environment-variable fallback
   - interactive prompt for missing org/project
   - repo create-or-reuse behavior
@@ -104,12 +104,12 @@ This plan does not modify them yet, but implementation will likely touch:
 
 - `scripts/tests/` or a new BATS suite for Azure helpers
 - `azure-pipelines.yml`
-- `bin/pyjenkinsapi-bootstrap`
-- `bin/pyjenkinsapi-lint`
-- `bin/pyjenkinsapi-review`
+- `bin/ai-bootstrap`
+- `bin/ai-lint`
+- `bin/ai-review`
 - `bin/pyjenkinsapi-azure-policy` or the future branch-policy helper script
 - `bin/pyjenkinsapi-azure-secret-rotate` or the future secret rotation helper script
-- `bin/pyjenkinsapi-azure-upload`
+- `bin/ai-upload`
 - `memory-bank/activeContext.md`
 - `memory-bank/progress.md`
 

--- a/docs/plans/2026-05-03-azure-repo-upload-helper.md
+++ b/docs/plans/2026-05-03-azure-repo-upload-helper.md
@@ -43,7 +43,7 @@ The helper should make initial repo publication and later re-syncs repeatable fr
 ## Proposed Shape
 
 ### Script
-- Add a repo-local script with a clear name such as `bin/pyjenkinsapi-azure-upload`.
+- Add a repo-local script with a clear name such as `bin/ai-upload`.
 - Support:
   - organization URL or name
   - project

--- a/docs/plans/2026-05-03-review-output-pr-style.md
+++ b/docs/plans/2026-05-03-review-output-pr-style.md
@@ -1,4 +1,4 @@
-# Plan: GitHub PR-style review output for `pyjenkinsapi-review`
+# Plan: GitHub PR-style review output for `ai-review`
 
 **Date:** 2026-05-03  
 **Branch:** `pyjenkinsapi-v0.1.0`  
@@ -9,7 +9,7 @@
 
 ## Goal
 
-Make `bin/pyjenkinsapi-review` produce review output that is easier to read like a GitHub PR review:
+Make `bin/ai-review` produce review output that is easier to read like a GitHub PR review:
 
 - combine the user prompt with `--prompt-file` context by referencing the file path instead of replacing one with the other
 - ask Copilot for a structured review response with a short summary and findings
@@ -68,7 +68,7 @@ This is a wrapper UX change, not a change to the vendored `rigor-cli` subtree.
 
 This plan does not modify them yet, but implementation will likely touch:
 
-- `bin/pyjenkinsapi-review`
+- `bin/ai-review`
 - `.github/copilot-instructions.md` if the prompt contract needs reinforcement
 - `memory-bank/activeContext.md`
 - `memory-bank/progress.md`
@@ -78,7 +78,7 @@ This plan does not modify them yet, but implementation will likely touch:
 
 ## Definition of Done for the Future Implementation
 
-- `bin/pyjenkinsapi-review` combines `--prompt` and `--prompt-file` into one final prompt instead of replacing one with the other.
+- `bin/ai-review` combines `--prompt` and `--prompt-file` into one final prompt instead of replacing one with the other.
 - The final prompt requests a PR-style review response with a short summary and explicit findings.
 - Local review runs produce visible, structured output that is easier to read than an empty success code.
 - Large `--prompt-file` inputs are referenced by path to keep the prompt size manageable.

--- a/docs/plans/2026-05-03-review-prompt-file-redaction.md
+++ b/docs/plans/2026-05-03-review-prompt-file-redaction.md
@@ -1,4 +1,4 @@
-# Plan: Redact forbidden fragments from `pyjenkinsapi-review` prompt-file input
+# Plan: Redact forbidden fragments from `ai-review` prompt-file input
 
 **Date:** 2026-05-03  
 **Branch:** `pyjenkinsapi-v0.1.0`  
@@ -9,7 +9,7 @@
 
 ## Goal
 
-Teach `bin/pyjenkinsapi-review` to sanitize prompt-file content before it reaches the vendored `rigor-cli` prompt guard.
+Teach `bin/ai-review` to sanitize prompt-file content before it reaches the vendored `rigor-cli` prompt guard.
 
 The wrapper should keep the current PR-style review UX, but ensure that review diffs containing blocked shell fragments are redacted before Copilot sees them.
 
@@ -62,7 +62,7 @@ The wrapper should keep the current PR-style review UX, but ensure that review d
 
 This plan does not modify them yet, but implementation will likely touch:
 
-- `bin/pyjenkinsapi-review`
+- `bin/ai-review`
 - `memory-bank/activeContext.md`
 - `memory-bank/progress.md`
 - `memory-bank/change-log.md`
@@ -72,7 +72,7 @@ This plan does not modify them yet, but implementation will likely touch:
 
 ## Definition of Done for the Future Implementation
 
-- `bin/pyjenkinsapi-review` redacts forbidden fragments from prompt text and prompt-file content before invoking `rigor review`.
+- `bin/ai-review` redacts forbidden fragments from prompt text and prompt-file content before invoking `rigor review`.
 - The wrapper passes a sanitized temporary file to `rigor review` when `--prompt-file` is used.
 - The original prompt-file remains unchanged.
 - A prompt-file containing blocked fragments no longer trips the vendored prompt guard.

--- a/docs/plans/2026-05-04-ai-review-fail-on-findings.md
+++ b/docs/plans/2026-05-04-ai-review-fail-on-findings.md
@@ -1,0 +1,52 @@
+# Plan: Let `ai-review` optionally fail CI on review findings
+
+**Branch:** `pyjenkinsapi-v0.1.1`  
+**Scope:** `bin/ai-review`, `scripts/tests/ai-review.bats`, README/docs references, memory-bank
+
+---
+
+## Problem
+
+`bin/ai-review` is useful as a human-facing review helper, but CI also needs a way to treat review findings as a failing signal. The default behavior should remain non-fatal for local use, but an explicit opt-in mode should let pipelines fail when review findings are present.
+
+## Proposed Behavior
+
+- Default behavior remains unchanged:
+  - successful review execution returns `0`
+  - findings are still visible in the output
+- Opt-in CI mode adds a failure signal when findings are present:
+  - support `--fail-on-findings`
+  - support `--exit-code` as a compatibility alias if needed
+  - when enabled, the wrapper asks the reviewer to emit a machine-readable result marker
+  - if the marker says findings are present, the wrapper exits non-zero after printing the review output
+- Backend errors still pass through as actual command failures.
+
+## Result Marker Contract
+
+When CI mode is enabled, the wrapper should append a small prompt instruction that asks the reviewer to end with a marker such as:
+
+- `AI_REVIEW_RESULT: no-findings`
+- `AI_REVIEW_RESULT: findings`
+
+The wrapper can then inspect the backend output after execution and decide whether to return `0` or `1`.
+
+## Files to Update
+
+- `bin/ai-review`
+- `scripts/tests/ai-review.bats`
+- `README.md`
+- memory-bank files
+
+## Validation
+
+- `shellcheck -S warning bin/ai-bootstrap bin/ai-lint bin/ai-review bin/ai-upload`
+- `bats scripts/tests/ai-review.bats`
+- direct smoke test with a stubbed `rigor` backend that emits findings and no-findings markers
+
+## Done When
+
+- Local review behavior is unchanged by default.
+- CI opt-in failure-on-findings behavior works and is documented.
+- Tests cover both marker outcomes.
+- Memory-bank records the new CI-review contract.
+

--- a/docs/plans/2026-05-04-ai-review-stdin-input.md
+++ b/docs/plans/2026-05-04-ai-review-stdin-input.md
@@ -1,0 +1,66 @@
+# Plan: Let `ai-review` accept stdin review context
+
+**Date:** 2026-05-04  
+**Branch:** `pyjenkinsapi-v0.1.1`
+
+---
+
+## Goal
+
+Teach `bin/ai-review` to accept review context from standard input when data is piped in, alongside the existing `--prompt` and `--prompt-file` inputs.
+
+This should let local shell usage work naturally:
+
+```bash
+git diff main...HEAD | bin/ai-review
+```
+
+and still preserve the current prompt composition and redaction behavior.
+
+---
+
+## Desired Behavior
+
+- Keep `--prompt` as the review instruction.
+- Keep `--prompt-file` as file-based review context.
+- If stdin is not a TTY and contains data, read it as additional review context.
+- Combine stdin content with `--prompt` and `--prompt-file` into the final review prompt.
+- Continue redacting forbidden shell fragments from all prompt sources before invoking `rigor review`.
+- Avoid reading from stdin when it is an interactive terminal.
+
+---
+
+## Constraints
+
+- Do not mutate prompt-file content on disk.
+- Preserve the PR-style output contract already built into `ai-review`.
+- Keep the wrapper shell-friendly and local-first.
+- Do not modify `tools/rigor-cli/`.
+
+---
+
+## Files Expected in the Implementation Phase
+
+- `bin/ai-review`
+- `scripts/tests/ai-review.bats`
+- `memory-bank/activeContext.md`
+- `memory-bank/progress.md`
+- `memory-bank/change-log.md`
+
+---
+
+## Definition of Done
+
+- Piped stdin is accepted as review context.
+- `--prompt`, `--prompt-file`, and stdin can be combined in one review run.
+- Existing redaction tests still pass.
+- A new local test covers stdin input behavior.
+- Memory-bank entries reflect the new stdin-input support.
+- The implementation is committed and pushed on `pyjenkinsapi-v0.1.1`.
+
+---
+
+## Notes
+
+- A plain interactive terminal should not be consumed accidentally.
+- stdin should behave like an extra context source, not a replacement for the existing prompt contract.

--- a/docs/plans/2026-05-04-bin-ai-helpers-naming.md
+++ b/docs/plans/2026-05-04-bin-ai-helpers-naming.md
@@ -1,0 +1,48 @@
+# Plan: Rename repo-local helper scripts to `ai-*`
+
+**Date:** 2026-05-04  
+**Branch:** `pyjenkinsapi-v0.1.1`
+
+---
+
+## Goal
+
+Normalize the repo-local helper names in `bin/` so they read cleanly in a single-repo context.
+
+Current intent:
+- `bin/ai-bootstrap`
+- `bin/ai-lint`
+- `bin/ai-review`
+- `bin/ai-upload`
+- `bin/rotate-secret`
+
+This replaces the verbose `pyjenkinsapi-*` prefix for AI/review automation while keeping the standalone secret rotation helper unprefixed.
+
+---
+
+## Scope
+
+Update all repo references that currently point at:
+- `bin/pyjenkinsapi-bootstrap`
+- `bin/pyjenkinsapi-lint`
+- `bin/pyjenkinsapi-review`
+- `bin/pyjenkinsapi-azure-upload`
+
+Keep `bin/rotate-secret` as the only unprefixed maintenance command in this group.
+
+---
+
+## DoD
+
+- Helper scripts renamed consistently in `bin/`
+- Workflow and docs references updated
+- Memory-bank entries updated to reflect the final helper names
+- Validation passes on renamed entrypoints
+
+---
+
+## Notes
+
+- This is a naming cleanup only.
+- It should not change helper behavior.
+- Any follow-up cleanup for CI docs or memory-bank phrasing should stay aligned with the renamed commands.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,7 +6,7 @@
 - `rigor-cli` remains vendored under `tools/rigor-cli/` and is treated as read-only tooling.
 - GitHub Actions CI and the review wrapper are now part of the shipped repo state.
 - Azure helper scripts, plans, and review/docs work remain available for future follow-up.
-- Helper naming cleanup is now queued: move repo-local `bin/pyjenkinsapi-*` scripts to `ai-*` names and keep `rotate-secret` unprefixed.
+- Helper naming cleanup is now implemented: repo-local helper scripts use `ai-*` names, and `rotate-secret` remains unprefixed.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -11,7 +11,7 @@
 - `ai-review` stdin help text is now fixed and documented in `--help`.
 - `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
 - Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
-- `ai-review` needs an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
+- `ai-review` now has an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -21,7 +21,7 @@
 - Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
 - Keep the stdin-help and backend handoff fixes aligned with the wrapper help text, README guidance, and vendored `rigor review` CLI contract.
 - Keep the recorded wrapper-contract review feedback aligned with the current `ai-review` stdin and backend behavior.
-- Keep the planned CI failure-on-findings behavior aligned with the existing PR-style review output contract.
+- Keep the CI failure-on-findings behavior aligned with the existing PR-style review output contract and result marker contract.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,22 +1,14 @@
 # Active Context
 
 ## Current Status
-- `pyjenkinsapi` PR #1 is merged into `main` on commit `9bf3ecd`.
-- Local branch now moved to `pyjenkinsapi-v0.1.1` from the merged `main` tip.
+- `main` is synced and branch protection is re-enabled.
+- Current working branch is `pyjenkinsapi-v0.1.3`.
 - `rigor-cli` remains vendored under `tools/rigor-cli/` and is treated as read-only tooling.
-- GitHub Actions CI and the review wrapper are now part of the shipped repo state.
+- Repo-local `ai-*` helpers, the legacy `pyjenkinsapi-review` alias, and GitHub Actions CI are in place.
 - Azure helper scripts, plans, and review/docs work remain available for future follow-up.
-- Helper naming cleanup is now implemented: repo-local helper scripts use `ai-*` names, and `rotate-secret` remains unprefixed.
-- `ai-review` stdin input support is now implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
-- `ai-review` stdin help text is now fixed and documented in `--help`.
-- `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
-- Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
-- `ai-review` now has an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
-- `pyjenkinsapi-review` compatibility alias has been restored so older scripts and habits keep working after the `ai-*` rename.
-- Copilot review feedback has been addressed by updating repo guidance, CI discovery patterns, review-context size handling, and the legacy alias contract.
+- A fresh draft PR now exists for `pyjenkinsapi-v0.1.3` at `https://github.com/wilddog64/pyjenkinsapi/pull/3`.
 
 ## Current Focus
-- Keep `main` protected again after the merge flow is complete.
 - Keep the next branch lean and focused on the next queued task.
 - Preserve compatibility for the legacy CLI and vendored tooling boundaries.
 - Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
@@ -26,6 +18,7 @@
 - Keep the CI failure-on-findings behavior aligned with the existing PR-style review output contract and result marker contract.
 - Keep the legacy review entrypoint compatibility alias aligned with `ai-review` behavior and docs.
 - Keep the CI review-context size guard aligned with the current diff generation approach.
+- Keep the new `pyjenkinsapi-v0.1.3` release branch aligned with the current shipped `main` state.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -12,6 +12,7 @@
 - `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
 - Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
 - `ai-review` now has an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
+- `pyjenkinsapi-review` still needs a thin compatibility alias so older scripts and habits do not break after the `ai-*` rename.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -22,6 +23,7 @@
 - Keep the stdin-help and backend handoff fixes aligned with the wrapper help text, README guidance, and vendored `rigor review` CLI contract.
 - Keep the recorded wrapper-contract review feedback aligned with the current `ai-review` stdin and backend behavior.
 - Keep the CI failure-on-findings behavior aligned with the existing PR-style review output contract and result marker contract.
+- Keep the legacy review entrypoint compatibility alias aligned with `ai-review` behavior and docs.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -8,8 +8,8 @@
 - Azure helper scripts, plans, and review/docs work remain available for future follow-up.
 - Helper naming cleanup is now implemented: repo-local helper scripts use `ai-*` names, and `rotate-secret` remains unprefixed.
 - `ai-review` stdin input support is now implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
-- `ai-review` stdin help text is now a queued bug fix because the wrapper accepts piped input but does not explain it in `--help`.
-- `ai-review` backend handoff is now blocked on a bug fix because the wrapper currently forwards an unsupported `--prompt-file` flag to the vendored backend.
+- `ai-review` stdin help text is now fixed and documented in `--help`.
+- `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -17,8 +17,7 @@
 - Preserve compatibility for the legacy CLI and vendored tooling boundaries.
 - Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
 - Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
-- Keep the stdin-help bug fix aligned with the wrapper help text and README guidance.
-- Keep the backend handoff fix aligned with the vendored `rigor review` CLI contract so the temp file remains internal to `ai-review`.
+- Keep the stdin-help and backend handoff fixes aligned with the wrapper help text, README guidance, and vendored `rigor review` CLI contract.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -11,6 +11,7 @@
 - `ai-review` stdin help text is now fixed and documented in `--help`.
 - `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
 - Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
+- `ai-review` needs an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -20,6 +21,7 @@
 - Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
 - Keep the stdin-help and backend handoff fixes aligned with the wrapper help text, README guidance, and vendored `rigor review` CLI contract.
 - Keep the recorded wrapper-contract review feedback aligned with the current `ai-review` stdin and backend behavior.
+- Keep the planned CI failure-on-findings behavior aligned with the existing PR-style review output contract.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -8,6 +8,7 @@
 - Azure helper scripts, plans, and review/docs work remain available for future follow-up.
 - Helper naming cleanup is now implemented: repo-local helper scripts use `ai-*` names, and `rotate-secret` remains unprefixed.
 - `ai-review` stdin input support is now implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
+- `ai-review` stdin help text is now a queued bug fix because the wrapper accepts piped input but does not explain it in `--help`.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -15,6 +16,7 @@
 - Preserve compatibility for the legacy CLI and vendored tooling boundaries.
 - Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
 - Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
+- Keep the stdin-help bug fix aligned with the wrapper help text and README guidance.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -19,6 +19,7 @@
 - Keep the legacy review entrypoint compatibility alias aligned with `ai-review` behavior and docs.
 - Keep the CI review-context size guard aligned with the current diff generation approach.
 - Keep the new `pyjenkinsapi-v0.1.3` release branch aligned with the current shipped `main` state.
+- Keep branch protection on `main` enabled after the merge and release handoff.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -12,7 +12,7 @@
 - `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
 - Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
 - `ai-review` now has an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
-- `pyjenkinsapi-review` still needs a thin compatibility alias so older scripts and habits do not break after the `ai-*` rename.
+- `pyjenkinsapi-review` compatibility alias has been restored so older scripts and habits keep working after the `ai-*` rename.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -7,12 +7,14 @@
 - GitHub Actions CI and the review wrapper are now part of the shipped repo state.
 - Azure helper scripts, plans, and review/docs work remain available for future follow-up.
 - Helper naming cleanup is now implemented: repo-local helper scripts use `ai-*` names, and `rotate-secret` remains unprefixed.
+- `ai-review` stdin input support is now implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
 - Keep the next branch lean and focused on the next queued task.
 - Preserve compatibility for the legacy CLI and vendored tooling boundaries.
 - Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
+- Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -13,6 +13,7 @@
 - Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
 - `ai-review` now has an opt-in CI failure mode so review findings can return non-zero without changing the default local review flow.
 - `pyjenkinsapi-review` compatibility alias has been restored so older scripts and habits keep working after the `ai-*` rename.
+- Copilot review feedback has been addressed by updating repo guidance, CI discovery patterns, review-context size handling, and the legacy alias contract.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -24,6 +25,7 @@
 - Keep the recorded wrapper-contract review feedback aligned with the current `ai-review` stdin and backend behavior.
 - Keep the CI failure-on-findings behavior aligned with the existing PR-style review output contract and result marker contract.
 - Keep the legacy review entrypoint compatibility alias aligned with `ai-review` behavior and docs.
+- Keep the CI review-context size guard aligned with the current diff generation approach.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -6,11 +6,13 @@
 - `rigor-cli` remains vendored under `tools/rigor-cli/` and is treated as read-only tooling.
 - GitHub Actions CI and the review wrapper are now part of the shipped repo state.
 - Azure helper scripts, plans, and review/docs work remain available for future follow-up.
+- Helper naming cleanup is now queued: move repo-local `bin/pyjenkinsapi-*` scripts to `ai-*` names and keep `rotate-secret` unprefixed.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
 - Keep the next branch lean and focused on the next queued task.
 - Preserve compatibility for the legacy CLI and vendored tooling boundaries.
+- Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,36 +1,16 @@
 # Active Context
 
 ## Current Status
-- Repository memory-bank now includes current-state tracking files to match the current Cline template.
-- `rigor-cli` is now vendored under `tools/rigor-cli/` on branch `pyjenkinsapi-v0.1.0` (subtree import at `a6d83d6`).
-- Azure pipeline implementation has started: repo-local bootstrap, lint, and review wrappers were added, and `azure-pipelines.yml` now wires them together.
-- Azure PR branch-policy helper planning is now queued to automate Azure Repos build validation from `bin/`.
-- Azure secret rotation helper planning remains queued as a separate maintenance command, similar in spirit to `bin/rotate-ghcr-pat`.
-- Azure CI helper test planning is now queued for the new wrappers, pipeline YAML, and Azure-specific helper scripts.
-- Azure repo upload helper is now implemented to publish `pyjenkinsapi` into Azure DevOps Git from `bin/`.
-- Azure repo upload helper now supports `--auto-detect` for detection-first org/project lookup and fails fast if org/project still cannot be inferred.
-- `.github/copilot-instructions.md` has been rewritten to focus on compatibility, repo boundaries, and CI review behavior.
-- `bin/pyjenkinsapi-review` now combines prompt instruction and `--prompt-file` diff context into a PR-style terminal review prompt, referencing large files by path instead of inlining them.
-- `bin/pyjenkinsapi-review` now redacts forbidden shell fragments from both prompt text and prompt-file content before invoking `rigor review` (`c0766be`).
-- A top-level `README.md` now mirrors the k3d-manager-style layout with Jenkins quick start, usage, architecture, directory layout, and docs sections.
-- A GitHub Actions CI workflow now lives at `.github/workflows/ci.yml` with a lint job and an optional PR review job on pull requests to `main`.
-- Copilot review comments on PR #1 are being addressed: the Copilot CLI install step is pinned to `v1.0.32`, and the vendored shellcheck workflow now runs `apt-get update` before installing shellcheck.
+- `pyjenkinsapi` PR #1 is merged into `main` on commit `9bf3ecd`.
+- Local branch now moved to `pyjenkinsapi-v0.1.1` from the merged `main` tip.
+- `rigor-cli` remains vendored under `tools/rigor-cli/` and is treated as read-only tooling.
+- GitHub Actions CI and the review wrapper are now part of the shipped repo state.
+- Azure helper scripts, plans, and review/docs work remain available for future follow-up.
 
 ## Current Focus
-- Keep `pyjenkinsapi` behavior stable while preserving the legacy-compatible CLI and module layout.
-- Treat `tools/rigor-cli/` as read-only vendored tooling unless the task explicitly refreshes the subtree.
-- Next task: implement the Azure PR branch-policy helper plan in `docs/plans/2026-05-03-azure-pr-branch-policy-helper.md` after approval.
-- Keep the Azure secret rotation helper plan aligned with the same `bin/` maintenance-command style.
-- Keep the Azure CI helper test plan aligned with the helper scripts and pipeline wiring.
-- Keep the Azure repo upload helper aligned with the same `bin/` maintenance-command style and confirm the branch upload mode before future changes.
-- Keep the Azure repo upload helper's detection-first behavior aligned with Azure CLI defaults and existing Azure remotes when values are not provided.
-- Keep `.github/copilot-instructions.md` aligned with the repository's compatibility surface and vendored tooling boundaries.
-- Keep `bin/pyjenkinsapi-review` aligned with the PR-style review output plan in `docs/plans/2026-05-03-review-output-pr-style.md`, especially the file-reference behavior for large diffs.
-- Keep `bin/pyjenkinsapi-review` aligned with the prompt-file redaction plan in `docs/plans/2026-05-03-review-prompt-file-redaction.md`, especially the sanitized temp-file behavior.
-- Keep the new top-level `README.md` aligned with the repo’s actual entrypoints, vendored tooling boundaries, and memory-bank docs.
-- Keep `.github/workflows/ci.yml` aligned with the repo’s helper scripts, vendored tooling boundaries, local BATS smoke tests, and PR review wrapper behavior.
-- Use this file for the next task's immediate context, recent decisions, and next steps.
+- Keep `main` protected again after the merge flow is complete.
+- Keep the next branch lean and focused on the next queued task.
+- Preserve compatibility for the legacy CLI and vendored tooling boundaries.
 
 ## Notes
-- Update this file after significant milestones or when the task direction changes.
-- Keep it concise and focused on the current work, not as a full history.
+- Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -10,6 +10,7 @@
 - `ai-review` stdin input support is now implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
 - `ai-review` stdin help text is now fixed and documented in `--help`.
 - `ai-review` backend handoff is now fixed so the wrapper keeps its temp handling internal and passes only supported arguments to the vendored backend.
+- Copilot review feedback for the `ai-review` wrapper contract has been captured in a bug note and resolved in `bf47e67`.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -18,6 +19,7 @@
 - Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
 - Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
 - Keep the stdin-help and backend handoff fixes aligned with the wrapper help text, README guidance, and vendored `rigor review` CLI contract.
+- Keep the recorded wrapper-contract review feedback aligned with the current `ai-review` stdin and backend behavior.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -9,6 +9,7 @@
 - Helper naming cleanup is now implemented: repo-local helper scripts use `ai-*` names, and `rotate-secret` remains unprefixed.
 - `ai-review` stdin input support is now implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
 - `ai-review` stdin help text is now a queued bug fix because the wrapper accepts piped input but does not explain it in `--help`.
+- `ai-review` backend handoff is now blocked on a bug fix because the wrapper currently forwards an unsupported `--prompt-file` flag to the vendored backend.
 
 ## Current Focus
 - Keep `main` protected again after the merge flow is complete.
@@ -17,6 +18,7 @@
 - Keep the helper naming cleanup aligned with the repo-local `bin/` surface and docs references.
 - Keep the stdin-input support aligned with the existing `ai-review` prompt composition and redaction behavior.
 - Keep the stdin-help bug fix aligned with the wrapper help text and README guidance.
+- Keep the backend handoff fix aligned with the vendored `rigor review` CLI contract so the temp file remains internal to `ai-review`.
 
 ## Notes
 - Update this file after the next significant milestone or direction change.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -36,6 +36,7 @@
 - Added a bug doc for the missing stdin help text in `ai-review` so the wrapper’s piped-input behavior is discoverable.
 - Added a bug doc for the backend `--prompt-file` leak so `ai-review` can keep its internal temp file private and only pass supported flags to `rigor review`.
 - Fixed `ai-review` help text and backend handoff so piped stdin is documented and the wrapper no longer forwards unsupported backend flags.
+- Recorded Copilot review feedback for the `ai-review` wrapper contract in a bug note and tied it to the existing `bf47e67` fix.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -35,6 +35,7 @@
 - Implemented stdin review-context support in `ai-review` and added BATS coverage plus direct smoke validation.
 - Added a bug doc for the missing stdin help text in `ai-review` so the wrapper’s piped-input behavior is discoverable.
 - Added a bug doc for the backend `--prompt-file` leak so `ai-review` can keep its internal temp file private and only pass supported flags to `rigor review`.
+- Fixed `ai-review` help text and backend handoff so piped stdin is documented and the wrapper no longer forwards unsupported backend flags.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -34,6 +34,7 @@
 - Added a plan to let `ai-review` accept piped stdin as review context alongside `--prompt` and `--prompt-file`.
 - Implemented stdin review-context support in `ai-review` and added BATS coverage plus direct smoke validation.
 - Added a bug doc for the missing stdin help text in `ai-review` so the wrapper’s piped-input behavior is discoverable.
+- Added a bug doc for the backend `--prompt-file` leak so `ai-review` can keep its internal temp file private and only pass supported flags to `rigor review`.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -30,6 +30,7 @@
 - Added `.github/workflows/ci.yml` and split it into lint and optional review jobs for pull requests to `main`.
 - Addressed Copilot PR review feedback by pinning the Copilot CLI install version in the workflow and adding `apt-get update` before shellcheck installation in the vendored workflow.
 - Added a naming plan to simplify repo-local helpers from `pyjenkinsapi-*` to `ai-*`, keeping `rotate-secret` unprefixed.
+- Renamed repo-local helper entrypoints to `ai-bootstrap`, `ai-lint`, `ai-review`, and `ai-upload`, and updated docs/workflows/tests to match.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -41,6 +41,7 @@
 - Implemented the `ai-review` CI failure-on-findings mode with a result marker contract and BATS coverage.
 - Added a bug note for the missing `pyjenkinsapi-review` compatibility alias after the helper rename.
 - Restored `bin/pyjenkinsapi-review` as a thin compatibility alias to `bin/ai-review` and covered the legacy path in tests.
+- Updated repo guidance and CI review context handling to match the renamed `ai-*` helpers and avoid oversized AI review prompts.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -37,6 +37,7 @@
 - Added a bug doc for the backend `--prompt-file` leak so `ai-review` can keep its internal temp file private and only pass supported flags to `rigor review`.
 - Fixed `ai-review` help text and backend handoff so piped stdin is documented and the wrapper no longer forwards unsupported backend flags.
 - Recorded Copilot review feedback for the `ai-review` wrapper contract in a bug note and tied it to the existing `bf47e67` fix.
+- Added a plan for opt-in CI failure-on-findings behavior in `ai-review` so pipelines can gate on review findings without changing the default local exit status.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -40,6 +40,7 @@
 - Added a plan for opt-in CI failure-on-findings behavior in `ai-review` so pipelines can gate on review findings without changing the default local exit status.
 - Implemented the `ai-review` CI failure-on-findings mode with a result marker contract and BATS coverage.
 - Added a bug note for the missing `pyjenkinsapi-review` compatibility alias after the helper rename.
+- Restored `bin/pyjenkinsapi-review` as a thin compatibility alias to `bin/ai-review` and covered the legacy path in tests.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -39,6 +39,7 @@
 - Recorded Copilot review feedback for the `ai-review` wrapper contract in a bug note and tied it to the existing `bf47e67` fix.
 - Added a plan for opt-in CI failure-on-findings behavior in `ai-review` so pipelines can gate on review findings without changing the default local exit status.
 - Implemented the `ai-review` CI failure-on-findings mode with a result marker contract and BATS coverage.
+- Added a bug note for the missing `pyjenkinsapi-review` compatibility alias after the helper rename.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -29,6 +29,7 @@
 - Added a top-level `README.md` in a k3d-manager-style layout tailored to pyjenkinsapi’s Jenkins CLI, vendored tooling, and helper scripts.
 - Added `.github/workflows/ci.yml` and split it into lint and optional review jobs for pull requests to `main`.
 - Addressed Copilot PR review feedback by pinning the Copilot CLI install version in the workflow and adding `apt-get update` before shellcheck installation in the vendored workflow.
+- Added a naming plan to simplify repo-local helpers from `pyjenkinsapi-*` to `ai-*`, keeping `rotate-secret` unprefixed.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -38,6 +38,7 @@
 - Fixed `ai-review` help text and backend handoff so piped stdin is documented and the wrapper no longer forwards unsupported backend flags.
 - Recorded Copilot review feedback for the `ai-review` wrapper contract in a bug note and tied it to the existing `bf47e67` fix.
 - Added a plan for opt-in CI failure-on-findings behavior in `ai-review` so pipelines can gate on review findings without changing the default local exit status.
+- Implemented the `ai-review` CI failure-on-findings mode with a result marker contract and BATS coverage.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -31,6 +31,8 @@
 - Addressed Copilot PR review feedback by pinning the Copilot CLI install version in the workflow and adding `apt-get update` before shellcheck installation in the vendored workflow.
 - Added a naming plan to simplify repo-local helpers from `pyjenkinsapi-*` to `ai-*`, keeping `rotate-secret` unprefixed.
 - Renamed repo-local helper entrypoints to `ai-bootstrap`, `ai-lint`, `ai-review`, and `ai-upload`, and updated docs/workflows/tests to match.
+- Added a plan to let `ai-review` accept piped stdin as review context alongside `--prompt` and `--prompt-file`.
+- Implemented stdin review-context support in `ai-review` and added BATS coverage plus direct smoke validation.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/change-log.md
+++ b/memory-bank/change-log.md
@@ -33,6 +33,7 @@
 - Renamed repo-local helper entrypoints to `ai-bootstrap`, `ai-lint`, `ai-review`, and `ai-upload`, and updated docs/workflows/tests to match.
 - Added a plan to let `ai-review` accept piped stdin as review context alongside `--prompt` and `--prompt-file`.
 - Implemented stdin review-context support in `ai-review` and added BATS coverage plus direct smoke validation.
+- Added a bug doc for the missing stdin help text in `ai-review` so the wrapper’s piped-input behavior is discoverable.
 
 ### Why
 To provide persistent engineering context for future contributors/agents and reduce repeated repository discovery work.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -26,5 +26,4 @@
 - `pyjenkinsapi-v0.1.3` is the current release branch and is tracked by draft PR #3.
 
 ## Next Steps
-- Re-enable branch protection on `main`.
 - Pick up the next scoped task on `pyjenkinsapi-v0.1.3`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -9,7 +9,7 @@
 - `ai-review` stdin help text is now fixed and documented in `--help`.
 - `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
 - Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
-- CI needs an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
+- CI now has an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -23,7 +23,7 @@
 - Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md` and resolved in `bin/ai-review`.
 - Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md` and resolved in `bin/ai-review`.
 - Wrapper-contract regression review feedback recorded in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bin/ai-review`.
-- Planned `ai-review` CI failure-on-findings behavior recorded in `docs/plans/2026-05-04-ai-review-fail-on-findings.md`.
+- `ai-review` CI failure-on-findings behavior recorded in `docs/plans/2026-05-04-ai-review-fail-on-findings.md` and implemented in `bin/ai-review`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -10,7 +10,7 @@
 - `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
 - Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
 - CI now has an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
-- The legacy `pyjenkinsapi-review` name still needs a compatibility shim so the rename to `ai-review` remains backwards compatible.
+- The legacy `pyjenkinsapi-review` compatibility shim is restored and covered by tests.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -26,6 +26,7 @@
 - Wrapper-contract regression review feedback recorded in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bin/ai-review`.
 - `ai-review` CI failure-on-findings behavior recorded in `docs/plans/2026-05-04-ai-review-fail-on-findings.md` and implemented in `bin/ai-review`.
 - Legacy `pyjenkinsapi-review` compatibility alias bug recorded in `docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md`.
+- Legacy `pyjenkinsapi-review` compatibility alias bug resolved with `bin/pyjenkinsapi-review`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,6 +6,7 @@
 - Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
 - Helper naming cleanup is implemented: repo-local helper scripts now use `ai-*` names, while `rotate-secret` stays unprefixed.
 - `ai-review` stdin input support is implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
+- `ai-review` stdin help text is missing and tracked as a bug doc so the wrapper can explain its piped-input behavior.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -16,6 +17,7 @@
 - Helper rename implementation has been applied to the repo-local helper scripts and workflow/docs references.
 - Stdin-input plan recorded in `docs/plans/2026-05-04-ai-review-stdin-input.md`.
 - `ai-review` stdin input is covered by local BATS tests and direct stdin smoke validation.
+- Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -9,6 +9,7 @@
 - `ai-review` stdin help text is now fixed and documented in `--help`.
 - `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
 - Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
+- CI needs an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -22,6 +23,7 @@
 - Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md` and resolved in `bin/ai-review`.
 - Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md` and resolved in `bin/ai-review`.
 - Wrapper-contract regression review feedback recorded in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bin/ai-review`.
+- Planned `ai-review` CI failure-on-findings behavior recorded in `docs/plans/2026-05-04-ai-review-fail-on-findings.md`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -11,6 +11,7 @@
 - Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
 - CI now has an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
 - The legacy `pyjenkinsapi-review` compatibility shim is restored and covered by tests.
+- Copilot feedback on stale helper references, CI discovery patterns, prompt-file test naming, and review-context sizing is resolved in the current branch.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -27,6 +28,7 @@
 - `ai-review` CI failure-on-findings behavior recorded in `docs/plans/2026-05-04-ai-review-fail-on-findings.md` and implemented in `bin/ai-review`.
 - Legacy `pyjenkinsapi-review` compatibility alias bug recorded in `docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md`.
 - Legacy `pyjenkinsapi-review` compatibility alias bug resolved with `bin/pyjenkinsapi-review`.
+- CI review-context generation now avoids `--binary` and trims oversized diff payloads before invoking Copilot review.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -8,6 +8,7 @@
 - `ai-review` stdin input support is implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
 - `ai-review` stdin help text is now fixed and documented in `--help`.
 - `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
+- Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -20,6 +21,7 @@
 - `ai-review` stdin input is covered by local BATS tests and direct stdin smoke validation.
 - Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md` and resolved in `bin/ai-review`.
 - Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md` and resolved in `bin/ai-review`.
+- Wrapper-contract regression review feedback recorded in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bin/ai-review`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,17 +1,11 @@
 # Progress
 
 ## Status
-- `pyjenkinsapi` is at the post-merge handoff point after PR #1 landed on `main`.
-- The current working branch is `pyjenkinsapi-v0.1.1`.
-- Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
-- Helper naming cleanup is implemented: repo-local helper scripts now use `ai-*` names, while `rotate-secret` stays unprefixed.
-- `ai-review` stdin input support is implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
-- `ai-review` stdin help text is now fixed and documented in `--help`.
-- `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
-- Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
-- CI now has an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
-- The legacy `pyjenkinsapi-review` compatibility shim is restored and covered by tests.
-- Copilot feedback on stale helper references, CI discovery patterns, prompt-file test naming, and review-context sizing is resolved in the current branch.
+- `main` is synced and branch protection is re-enabled.
+- The current working branch is `pyjenkinsapi-v0.1.3`.
+- Vendored `rigor-cli`, repo-local `ai-*` helpers, the legacy `pyjenkinsapi-review` alias, and GitHub Actions CI are stable.
+- Azure helper scripts and plans remain queued for the next milestone.
+- Draft PR #3 now tracks the `pyjenkinsapi-v0.1.3` release branch.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -29,7 +23,8 @@
 - Legacy `pyjenkinsapi-review` compatibility alias bug recorded in `docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md`.
 - Legacy `pyjenkinsapi-review` compatibility alias bug resolved with `bin/pyjenkinsapi-review`.
 - CI review-context generation now avoids `--binary` and trims oversized diff payloads before invoking Copilot review.
+- `pyjenkinsapi-v0.1.3` is the current release branch and is tracked by draft PR #3.
 
 ## Next Steps
 - Re-enable branch protection on `main`.
-- Pick up the next scoped task on `pyjenkinsapi-v0.1.1`.
+- Pick up the next scoped task on `pyjenkinsapi-v0.1.3`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,8 +6,8 @@
 - Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
 - Helper naming cleanup is implemented: repo-local helper scripts now use `ai-*` names, while `rotate-secret` stays unprefixed.
 - `ai-review` stdin input support is implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
-- `ai-review` stdin help text is missing and tracked as a bug doc so the wrapper can explain its piped-input behavior.
-- `ai-review` backend handoff is broken when stdin or prompt-file context is present because the wrapper forwards an unsupported `--prompt-file` flag to `rigor review`.
+- `ai-review` stdin help text is now fixed and documented in `--help`.
+- `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -18,8 +18,8 @@
 - Helper rename implementation has been applied to the repo-local helper scripts and workflow/docs references.
 - Stdin-input plan recorded in `docs/plans/2026-05-04-ai-review-stdin-input.md`.
 - `ai-review` stdin input is covered by local BATS tests and direct stdin smoke validation.
-- Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md`.
-- Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md`.
+- Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md` and resolved in `bin/ai-review`.
+- Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md` and resolved in `bin/ai-review`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,48 +1,16 @@
 # Progress
 
 ## Status
-- Memory-bank structure now includes `activeContext.md` and `progress.md` alongside the existing durable docs.
-- `rigor-cli` is vendored under `tools/rigor-cli/` on branch `pyjenkinsapi-v0.1.0`.
-- Azure pipeline implementation has started with repo-local bootstrap, lint, and review wrappers plus `azure-pipelines.yml`.
-- Azure PR branch-policy helper planning is queued for Azure DevOps PR validation automation.
-- Azure secret rotation helper planning remains queued as a `bin/` maintenance command.
-- Azure CI helper test planning is queued for the new wrappers and Azure-specific helper scripts.
-- Azure repo upload helper is implemented for publishing `pyjenkinsapi` into Azure DevOps Git from `bin/`.
-- Azure repo upload helper now supports `--auto-detect` for detection-first org/project lookup and fails fast if org/project still cannot be inferred.
-- `.github/copilot-instructions.md` now gives repo-specific review guidance for compatibility, CI behavior, and vendored tooling boundaries.
-- Review wrapper output now combines prompt instruction and diff context into a PR-style terminal review prompt, referencing large files by path to keep the prompt manageable.
-- Prompt-file redaction is implemented in `bin/pyjenkinsapi-review` (`c0766be`) so blocked shell fragments are sanitized before invoking `rigor review`.
-- Top-level `README.md` has been added in a k3d-manager-style layout for Jenkins quick start, usage, architecture, directory layout, and docs.
-- GitHub Actions CI workflow split into lint and optional review jobs at `.github/workflows/ci.yml` for pull requests to `main`.
-- Copilot review comments on PR #1 are being resolved with a pinned Copilot CLI version and a vendored shellcheck install that runs `apt-get update` first.
+- `pyjenkinsapi` is at the post-merge handoff point after PR #1 landed on `main`.
+- The current working branch is `pyjenkinsapi-v0.1.1`.
+- Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
 
 ## Milestones
-- Project overview documented in `memory-bank/project-overview.md`.
-- Architecture notes documented in `memory-bank/architecture-notes.md`.
-- Development workflow documented in `memory-bank/development-playbook.md`.
-- Change history captured in `memory-bank/change-log.md`.
-- Vendored tooling imported under `tools/rigor-cli/`.
-- Azure pipeline plan recorded in `docs/plans/2026-05-03-azure-pipeline-lint-review.md`.
-- Dependency/bootstrap stage recorded as part of the Azure pipeline plan.
-- Azure secret rotation helper plan recorded in `docs/plans/2026-05-03-azure-secret-rotation-helper.md`.
-- Azure review instructions/prompt plan recorded in `docs/plans/2026-05-03-azure-review-instructions-and-prompt.md`.
-- Azure PR branch-policy helper plan recorded in `docs/plans/2026-05-03-azure-pr-branch-policy-helper.md`.
-- Azure CI helper test plan recorded in `docs/plans/2026-05-03-azure-ci-helper-tests.md`.
-- Azure repo upload helper plan recorded in `docs/plans/2026-05-03-azure-repo-upload-helper.md`; helper now added under `bin/`.
-- Azure repo upload helper now has detection-first lookup via `--auto-detect` and non-interactive failure when values are unavailable.
-- Copilot instructions refreshed for `pyjenkinsapi` review workflows.
-- PR-style review output plan recorded in `docs/plans/2026-05-03-review-output-pr-style.md`.
-- PR-style review prompt composition implemented in `bin/pyjenkinsapi-review`, including file-reference handling for large diffs.
-- PR-style review prompt sanitization is implemented for `bin/pyjenkinsapi-review`, with tests covering redaction and inline prompt-file mode.
-- README alignment is tracked in the memory bank so the new top-level docs stay consistent with the repo’s entrypoints and vendored tooling.
-- GitHub Actions workflow alignment is tracked so CI stays consistent with the repo-local helper scripts, smoke tests, and PR review wrapper behavior.
-- Repo-local bootstrap/lint/review wrappers added under `bin/`.
-- Azure pipeline YAML added at `azure-pipelines.yml`.
-- The Azure secret rotation helper is intended to mirror the usability of `bin/rotate-ghcr-pat`.
+- `activeContext.md` and `progress.md` are in use for current-state tracking.
+- `tools/rigor-cli/` is vendored under the repo.
+- Repo-local bootstrap/lint/review wrappers are implemented under `bin/`.
+- GitHub Actions CI is split into lint and review jobs.
 
 ## Next Steps
-- Await approval to implement the Azure PR branch-policy helper plan, then keep the pipeline/review helpers aligned as needed.
-- Await approval to implement the Azure CI helper tests plan once the Azure helper scripts are in their final shape.
-- Revisit the Azure repo upload helper after the first Azure DevOps import to confirm whether all-branches/tags or current-branch mode should be the default.
-- Revisit the Azure repo upload helper's detection order after first use to confirm whether the fallback order should change.
-- Keep summaries brief and use linked docs for longer details.
+- Re-enable branch protection on `main`.
+- Pick up the next scoped task on `pyjenkinsapi-v0.1.1`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,12 +4,14 @@
 - `pyjenkinsapi` is at the post-merge handoff point after PR #1 landed on `main`.
 - The current working branch is `pyjenkinsapi-v0.1.1`.
 - Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
+- Helper naming cleanup is queued to rename `bin/pyjenkinsapi-*` scripts to `ai-*`, while leaving `bin/rotate-secret` unprefixed.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
 - `tools/rigor-cli/` is vendored under the repo.
 - Repo-local bootstrap/lint/review wrappers are implemented under `bin/`.
 - GitHub Actions CI is split into lint and review jobs.
+- Helper naming plan recorded in `docs/plans/2026-05-04-bin-ai-helpers-naming.md`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -10,6 +10,7 @@
 - `ai-review` backend handoff now keeps its temp handling internal and passes only supported arguments to `rigor review`.
 - Copilot review feedback for the `ai-review` wrapper contract is documented in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bf47e67`.
 - CI now has an opt-in failure mode for review findings so `ai-review` can gate pipelines without breaking the default local workflow.
+- The legacy `pyjenkinsapi-review` name still needs a compatibility shim so the rename to `ai-review` remains backwards compatible.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -24,6 +25,7 @@
 - Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md` and resolved in `bin/ai-review`.
 - Wrapper-contract regression review feedback recorded in `docs/bugs/2026-05-04-ai-review-wrapper-contract-regression.md` and resolved in `bin/ai-review`.
 - `ai-review` CI failure-on-findings behavior recorded in `docs/plans/2026-05-04-ai-review-fail-on-findings.md` and implemented in `bin/ai-review`.
+- Legacy `pyjenkinsapi-review` compatibility alias bug recorded in `docs/bugs/2026-05-04-pyjenkinsapi-review-compatibility-alias-missing.md`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -7,6 +7,7 @@
 - Helper naming cleanup is implemented: repo-local helper scripts now use `ai-*` names, while `rotate-secret` stays unprefixed.
 - `ai-review` stdin input support is implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
 - `ai-review` stdin help text is missing and tracked as a bug doc so the wrapper can explain its piped-input behavior.
+- `ai-review` backend handoff is broken when stdin or prompt-file context is present because the wrapper forwards an unsupported `--prompt-file` flag to `rigor review`.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -18,6 +19,7 @@
 - Stdin-input plan recorded in `docs/plans/2026-05-04-ai-review-stdin-input.md`.
 - `ai-review` stdin input is covered by local BATS tests and direct stdin smoke validation.
 - Stdin-help bug recorded in `docs/bugs/2026-05-04-ai-review-stdin-help-missing.md`.
+- Backend-prompt-file leak bug recorded in `docs/bugs/2026-05-04-ai-review-backend-prompt-file-leak.md`.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,6 +5,7 @@
 - The current working branch is `pyjenkinsapi-v0.1.1`.
 - Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
 - Helper naming cleanup is implemented: repo-local helper scripts now use `ai-*` names, while `rotate-secret` stays unprefixed.
+- `ai-review` stdin input support is implemented so piped review context can be combined with `--prompt` and `--prompt-file`.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -13,6 +14,8 @@
 - GitHub Actions CI is split into lint and review jobs.
 - Helper naming plan recorded in `docs/plans/2026-05-04-bin-ai-helpers-naming.md`.
 - Helper rename implementation has been applied to the repo-local helper scripts and workflow/docs references.
+- Stdin-input plan recorded in `docs/plans/2026-05-04-ai-review-stdin-input.md`.
+- `ai-review` stdin input is covered by local BATS tests and direct stdin smoke validation.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -4,7 +4,7 @@
 - `pyjenkinsapi` is at the post-merge handoff point after PR #1 landed on `main`.
 - The current working branch is `pyjenkinsapi-v0.1.1`.
 - Vendored `rigor-cli`, GitHub Actions CI, and the review wrapper are all in place.
-- Helper naming cleanup is queued to rename `bin/pyjenkinsapi-*` scripts to `ai-*`, while leaving `bin/rotate-secret` unprefixed.
+- Helper naming cleanup is implemented: repo-local helper scripts now use `ai-*` names, while `rotate-secret` stays unprefixed.
 
 ## Milestones
 - `activeContext.md` and `progress.md` are in use for current-state tracking.
@@ -12,6 +12,7 @@
 - Repo-local bootstrap/lint/review wrappers are implemented under `bin/`.
 - GitHub Actions CI is split into lint and review jobs.
 - Helper naming plan recorded in `docs/plans/2026-05-04-bin-ai-helpers-naming.md`.
+- Helper rename implementation has been applied to the repo-local helper scripts and workflow/docs references.
 
 ## Next Steps
 - Re-enable branch protection on `main`.

--- a/scripts/tests/ai-review.bats
+++ b/scripts/tests/ai-review.bats
@@ -197,3 +197,42 @@ EOF
   [[ "$output" == *"No findings"* ]]
   [[ "$output" == *"AI_REVIEW_RESULT: no-findings"* ]]
 }
+
+@test "pyjenkinsapi-review compatibility alias preserves stdin" {
+  stub_dir="$(mktemp -d)"
+  make_stub_rigor "$stub_dir"
+
+  stdin_file="$(mktemp)"
+  cat >"$stdin_file" <<'EOF'
+diff --git a/legacy.py b/legacy.py
+--- a/legacy.py
++++ b/legacy.py
+@@ -1 +1 @@
+-legacy content
++legacy content
+EOF
+
+  run env \
+    PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
+    PYJENKINSAPI_REVIEW_STREAM=off \
+    bash -c 'cd "$1" && cat "$2" | ./bin/pyjenkinsapi-review --prompt "review these change"' _ "$repo_root" "$stdin_file"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Review context from stdin:"* ]]
+  [[ "$output" != *"PROMPT_FILE<<EOF"* ]]
+}
+
+@test "pyjenkinsapi-review compatibility alias preserves fail-on-findings" {
+  stub_dir="$(mktemp -d)"
+  make_stub_rigor "$stub_dir"
+
+  run env \
+    PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
+    PYJENKINSAPI_REVIEW_STREAM=off \
+    RIGOR_STUB_OUTPUT=$'Summary\n\nFindings\n- one issue\n\nAI_REVIEW_RESULT: findings' \
+    bash -c 'cd "$1" && ./bin/pyjenkinsapi-review --exit-code --prompt "review these change"' _ "$repo_root"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Findings"* ]]
+  [[ "$output" == *"AI_REVIEW_RESULT: findings"* ]]
+}

--- a/scripts/tests/ai-review.bats
+++ b/scripts/tests/ai-review.bats
@@ -94,3 +94,65 @@ EOF
   [[ "$output" == *"[redacted restricted shell fragment]"* ]]
   [[ "$output" != *"shell(git push --force)"* ]]
 }
+
+@test "ai-review: accepts stdin review context" {
+  stub_dir="$(mktemp -d)"
+  make_stub_rigor "$stub_dir"
+
+  stdin_file="$(mktemp)"
+  cat >"$stdin_file" <<'EOF'
+diff --git a/example.py b/example.py
+--- a/example.py
++++ b/example.py
+@@ -1,2 +1,2 @@
+-shell(git push --force)
++shell(git push --force)
+EOF
+
+  run env \
+    PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
+    PYJENKINSAPI_REVIEW_STREAM=off \
+    AI_REVIEW_BIN="$repo_root/bin/ai-review" \
+    bash -c 'cat "$1" | "$AI_REVIEW_BIN" --prompt "review these change"' _ "$stdin_file"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROMPT_FILE<<EOF"* ]]
+  [[ "$output" == *"[redacted restricted shell fragment]"* ]]
+  [[ "$output" != *"shell(git push --force)"* ]]
+}
+
+@test "ai-review: combines stdin and prompt-file context" {
+  stub_dir="$(mktemp -d)"
+  make_stub_rigor "$stub_dir"
+
+  prompt_file="$(mktemp)"
+  cat >"$prompt_file" <<'EOF'
+diff --git a/prompt-file.py b/prompt-file.py
+--- a/prompt-file.py
++++ b/prompt-file.py
+@@ -1 +1 @@
+-prompt-file content
++prompt-file content
+EOF
+
+  stdin_file="$(mktemp)"
+  cat >"$stdin_file" <<'EOF'
+diff --git a/stdin.py b/stdin.py
+--- a/stdin.py
++++ b/stdin.py
+@@ -1 +1 @@
+-stdin content
++stdin content
+EOF
+
+  run env \
+    PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
+    PYJENKINSAPI_REVIEW_STREAM=off \
+    AI_REVIEW_BIN="$repo_root/bin/ai-review" \
+    bash -c 'cat "$1" | "$AI_REVIEW_BIN" --prompt "review these change" --prompt-file "$2"' _ "$stdin_file" "$prompt_file"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"prompt-file content"* ]]
+  [[ "$output" == *"stdin content"* ]]
+  [[ "$output" == *"contains both the prompt-file and stdin content"* ]]
+}

--- a/scripts/tests/ai-review.bats
+++ b/scripts/tests/ai-review.bats
@@ -77,7 +77,7 @@ EOF
   [[ "$output" == *"shell(git push --force)"* ]]
 }
 
-@test "ai-review: sanitizes inline prompt-file mode" {
+@test "ai-review: redacts forbidden fragments from prompt-file mode" {
   stub_dir="$(mktemp -d)"
   make_stub_rigor "$stub_dir"
 
@@ -88,7 +88,6 @@ EOF
 
   run env \
     PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
-    PYJENKINSAPI_REVIEW_INLINE_PROMPT_FILE=1 \
     PYJENKINSAPI_REVIEW_STREAM=off \
     "$repo_root/bin/ai-review" \
     --prompt "review these change" \

--- a/scripts/tests/ai-review.bats
+++ b/scripts/tests/ai-review.bats
@@ -44,7 +44,7 @@ EOF
   chmod +x "$stub_dir/rigor"
 }
 
-@test "pyjenkinsapi-review: redacts forbidden fragments from prompt and prompt-file" {
+@test "ai-review: redacts forbidden fragments from prompt and prompt-file" {
   stub_dir="$(mktemp -d)"
   make_stub_rigor "$stub_dir"
 
@@ -62,7 +62,7 @@ EOF
     PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
     PYJENKINSAPI_REVIEW_PROMPT="review shell(git push --force)" \
     PYJENKINSAPI_REVIEW_STREAM=off \
-    "$repo_root/bin/pyjenkinsapi-review" \
+    "$repo_root/bin/ai-review" \
     --prompt-file "$prompt_file"
 
   [ "$status" -eq 0 ]
@@ -73,7 +73,7 @@ EOF
   [[ "$output" == *"shell(git push --force)"* ]]
 }
 
-@test "pyjenkinsapi-review: sanitizes inline prompt-file mode" {
+@test "ai-review: sanitizes inline prompt-file mode" {
   stub_dir="$(mktemp -d)"
   make_stub_rigor "$stub_dir"
 
@@ -86,7 +86,7 @@ EOF
     PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
     PYJENKINSAPI_REVIEW_INLINE_PROMPT_FILE=1 \
     PYJENKINSAPI_REVIEW_STREAM=off \
-    "$repo_root/bin/pyjenkinsapi-review" \
+    "$repo_root/bin/ai-review" \
     --prompt "review these change" \
     --prompt-file "$prompt_file"
 

--- a/scripts/tests/ai-review.bats
+++ b/scripts/tests/ai-review.bats
@@ -116,7 +116,8 @@ EOF
     bash -c 'cat "$1" | "$AI_REVIEW_BIN" --prompt "review these change"' _ "$stdin_file"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"PROMPT_FILE<<EOF"* ]]
+  [[ "$output" != *"PROMPT_FILE<<EOF"* ]]
+  [[ "$output" == *"Review context from stdin:"* ]]
   [[ "$output" == *"[redacted restricted shell fragment]"* ]]
   [[ "$output" != *"shell(git push --force)"* ]]
 }
@@ -152,7 +153,9 @@ EOF
     bash -c 'cat "$1" | "$AI_REVIEW_BIN" --prompt "review these change" --prompt-file "$2"' _ "$stdin_file" "$prompt_file"
 
   [ "$status" -eq 0 ]
+  [[ "$output" != *"PROMPT_FILE<<EOF"* ]]
   [[ "$output" == *"prompt-file content"* ]]
   [[ "$output" == *"stdin content"* ]]
-  [[ "$output" == *"contains both the prompt-file and stdin content"* ]]
+  [[ "$output" == *"Review context from --prompt-file"* ]]
+  [[ "$output" == *"Review context from stdin:"* ]]
 }

--- a/scripts/tests/ai-review.bats
+++ b/scripts/tests/ai-review.bats
@@ -36,9 +36,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-printf 'PROMPT<<EOF\n%s\nEOF\n' "$prompt"
-if [[ -n "$prompt_file" ]]; then
-  printf 'PROMPT_FILE<<EOF\n%s\nEOF\n' "$(cat "$prompt_file")"
+if [[ -n "${RIGOR_STUB_OUTPUT:-}" ]]; then
+  printf '%s\n' "$RIGOR_STUB_OUTPUT"
+else
+  printf 'PROMPT<<EOF\n%s\nEOF\n' "$prompt"
+  if [[ -n "$prompt_file" ]]; then
+    printf 'PROMPT_FILE<<EOF\n%s\nEOF\n' "$(cat "$prompt_file")"
+  fi
 fi
 EOF
   chmod +x "$stub_dir/rigor"
@@ -158,4 +162,38 @@ EOF
   [[ "$output" == *"stdin content"* ]]
   [[ "$output" == *"Review context from --prompt-file"* ]]
   [[ "$output" == *"Review context from stdin:"* ]]
+}
+
+@test "ai-review: fail-on-findings returns 1 when marker says findings" {
+  stub_dir="$(mktemp -d)"
+  make_stub_rigor "$stub_dir"
+
+  run env \
+    PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
+    PYJENKINSAPI_REVIEW_STREAM=off \
+    RIGOR_STUB_OUTPUT=$'Summary\n\nFindings\n- one issue\n\nAI_REVIEW_RESULT: findings' \
+    "$repo_root/bin/ai-review" \
+    --exit-code \
+    --prompt "review these change"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Findings"* ]]
+  [[ "$output" == *"AI_REVIEW_RESULT: findings"* ]]
+}
+
+@test "ai-review: fail-on-findings returns 0 when marker says no-findings" {
+  stub_dir="$(mktemp -d)"
+  make_stub_rigor "$stub_dir"
+
+  run env \
+    PYJENKINSAPI_RIGOR_BIN="$stub_dir/rigor" \
+    PYJENKINSAPI_REVIEW_FAIL_ON_FINDINGS=1 \
+    PYJENKINSAPI_REVIEW_STREAM=off \
+    RIGOR_STUB_OUTPUT=$'Summary\n\nNo findings\n\nAI_REVIEW_RESULT: no-findings' \
+    "$repo_root/bin/ai-review" \
+    --prompt "review these change"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No findings"* ]]
+  [[ "$output" == *"AI_REVIEW_RESULT: no-findings"* ]]
 }


### PR DESCRIPTION
Release branch for the current pyjenkinsapi state after the review-wrapper and compatibility-alias work.\n\nThis branch is the renamed successor to the stale pr-2 / Snyk head and is intended to be the release line for v0.1.3.